### PR TITLE
curtin-ci: keep 7 days of job results, up to 40 jobs 

### DIFF
--- a/curtin/jobs-ci.yaml
+++ b/curtin/jobs-ci.yaml
@@ -67,6 +67,10 @@
             - metal-ppc64el
             - metal-arm64
             - metal-s390x
+    properties:
+      - build-discarder:
+          days-to-keep: 7
+          num-to-keep: 40
     parameters:
       - landing-candidate
       - landing-candidate-branch


### PR DESCRIPTION
Keep 10 curtin-ci builds, up from the 3 we are keeping by default. One
build is about 26MB big, so we can easily afford to keep 10.