### PR TITLE
cloud-init-integration-ec2-f: fix the the timed trigger

### DIFF
--- a/cloud-init/integration-ec2.yaml
+++ b/cloud-init/integration-ec2.yaml
@@ -64,7 +64,7 @@
     name: cloud-init-integration-ec2-f
     node: torkoal
     triggers:
-      - timed: "H 0 * * 8"
+      - timed: "H 0 * * 6"
     publishers:
       - email-server-crew
       - archive-results


### PR DESCRIPTION
Number 8 in the day of the week field does not make sense and it's
ignored by Jenkins.