### PR TITLE
curtin: add vmtest jobs for proposed-focal and daily for groovy

### DIFF
--- a/curtin/default.yaml
+++ b/curtin/default.yaml
@@ -59,10 +59,13 @@
       - curtin-vmtest-daily-x
       - curtin-vmtest-daily-b
       - curtin-vmtest-daily-f
+      - curtin-vmtest-daily-g
       - curtin-vmtest-proposed-b
       - curtin-vmtest-proposed-b-trigger
       - curtin-vmtest-proposed-e
       - curtin-vmtest-proposed-e-trigger
+      - curtin-vmtest-proposed-f
+      - curtin-vmtest-proposed-f-trigger
       - curtin-vmtest-proposed-x
       - curtin-vmtest-proposed-x-trigger
 

--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -61,7 +61,7 @@
       - nose-args:
           default_nose_args:
     triggers:
-      - timed: "H 4 * * 2,5,6"
+      - timed: "H 4 * * 2,5"
     publishers:
       - email-server-crew
       - archive-results
@@ -71,6 +71,25 @@
     builders:
       - vmtest-daily:
           release: focal
+          nose_args: nose_args
+
+- job:
+    name: curtin-vmtest-daily-g
+    node: torkoal
+    parameters:
+      - nose-args:
+          default_nose_args:
+    triggers:
+      - timed: "H 4 * * 6"
+    publishers:
+      - email-server-crew
+      - archive-results
+    wrappers:
+      - timestamps
+      - workspace-cleanup
+    builders:
+      - vmtest-daily:
+          release: groovy
           nose_args: nose_args
 
 - builder:

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -59,6 +59,20 @@
           release: eoan
           triggerwhat: curtin-vmtest-proposed-e
 
+- job:
+    name: curtin-vmtest-proposed-f-trigger
+    node: torkoal
+    triggers:
+      - timed: "H 10 * * 3,6"
+    publishers:
+      - email-server-crew
+    wrappers:
+      - workspace-cleanup
+    builders:
+      - vmtest-proposed-trigger:
+          release: focal
+          triggerwhat: curtin-vmtest-proposed-f
+
 - builder:
     name: vmtest-proposed-trigger
     builders:

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -132,6 +132,20 @@
       - vmtest-proposed:
           release: eoan
 
+- job:
+    name: curtin-vmtest-proposed-f
+    node: torkoal
+    auth-token: BUILD_ME
+    publishers:
+      - email-server-crew
+      - archive-results
+    wrappers:
+      - timestamps
+      - workspace-cleanup
+    builders:
+      - vmtest-proposed:
+          release: focal
+
 - builder:
     name: vmtest-proposed
     builders:


### PR DESCRIPTION
With vmtests we want to make sure to avoid overloading our CI infrastructure, so cron jobs need to be scheduled on different days.

This schedule 'striping' is especially important for curtin vmtests because the load is so heavy and test runs are so long. 

- Add a vmtest groovy job for curtin to get once weekly CI coverage on the 6th day of the week.
- Adjust curtin-vmtest-daily-f dropping this 3rd test schedule from days 2,5,6 to just 2,5

- Add a proposed vmtest for focal (so that vmtests can run against what cloud-init has uploaded
   to the -proposed pocket for automated SRU verification into focal.
