### PR TITLE
metrics: timestamp the builds and add a timeout

### DIFF
--- a/metrics/default.yaml
+++ b/metrics/default.yaml
@@ -58,6 +58,11 @@
     node: metal-amd64
     triggers:
       - timed: "H * * * *"
+    wrappers:
+      - timestamps
+      - timeout:
+          timeout: 30
+          fail: true
     properties:
       - build-discarder:
           num-to-keep: 25


### PR DESCRIPTION
A timeout of 30 minutes should good to prevent stuck jobs from being
unnoticed without killing occasionally slow jobs.

Closes #125