### PR TITLE
Bump the docker image size for the 'latest' image

### DIFF
--- a/docker/image-size.yaml
+++ b/docker/image-size.yaml
@@ -39,7 +39,7 @@
           description: "Ubuntu docker tag to pull."
       - string:
           name: MAXSIZE
-          default: !j2: "{{ {'latest': 72, 'rolling': 80, 'devel': 80}[dockertag] }}"
+          default: !j2: "{{ {'latest': 75, 'rolling': 80, 'devel': 80}[dockertag] }}"
           description: 'Maximum size of the Docker image'
     triggers:
       - timed: '@daily'


### PR DESCRIPTION
Focal exceeds the previous 72MB limit.