### PR TITLE
cloud-init tip jobs: fix the tox environments

### DIFF
--- a/cloud-init/other.yaml
+++ b/cloud-init/other.yaml
@@ -33,8 +33,7 @@
 
           git clone https://git.launchpad.net/cloud-init
           cd cloud-init
-          tox -e tip-pycodestyle
-          tox -e tip-pyflakes
+          tox -e tip-flake8
           tox -e tip-pylint
 
 - job:


### PR DESCRIPTION
cloud-init commit a99c8bcea597c17d83d90bf1e09c9a5b68c3dc22 replaced the
tip-pycodestyle and tip-pyflakes tox environments with the tip-flake8
environment. This adapts the cloud-init-style-tip job to the change.