### PR TITLE
Add JamesLucas to the bug triage rotation

### DIFF
--- a/daily-triage/tableflip-triage-email.sh
+++ b/daily-triage/tableflip-triage-email.sh
@@ -28,12 +28,21 @@ core_committers="blackboxsw,OddBloke,raharper"
 
 # Find today's triager. On Mondays triage the weekend's bugs.
 ndays=1
-triagers=(Dan Ryan Chad Paride)
+triagers=(Dan JamesLucas Chad Paride)
 week=$(date --utc '+%-V')
+isEven=$(( $week % 2 ))
 dow=$(date --utc '+%u')
 if [[ "$dow" -ge 2 && "$dow" -le 5 ]]; then
     ndays=1
     triager=${triagers[$((dow-2))]}
+    if [ $triager == "JamesLucas" ]; then
+        if [ $isEven -eq 0 ]
+        then
+          triager="James"
+        else
+          triager="Lucas"
+        fi
+    fi
 elif [[ "$dow" -eq 1 ]]; then
     # Mondays!
     ndays=3


### PR DESCRIPTION
Add James and Lucas to the Wed schedule. 
Rotate them on even/odd weeks as well as for Monday rotation. 

Mondays are meant for James and Lucas to sort out since it'll always be every 4th week and consistently be even (this week is 29 and next week would be their rotation and week 30, then 34, etc). 