### PR TITLE
curtin: make curtainer use ubuntu-minimal images

### DIFF
--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -110,7 +110,12 @@
           PATH="$PWD/tools:$PATH"
 
           ./tools/vmtest-system-setup
-          ./tools/curtainer --"$TYPE" ubuntu-daily:"$RELEASE" --source=src "$LXC_NAME"
+
+          # We assume the ubuntu-minimal-daily LXD remote has been already added.
+          # This is normally done by the jenkins-slave-setup Ansible by running:
+          # lxc remote add --protocol simplestreams ubuntu-minimal-daily https://cloud-images.ubuntu.com/minimal/daily/
+          ./tools/curtainer --"$TYPE" ubuntu-minimal-daily:"$RELEASE" --source=src "$LXC_NAME"
+
           cd src
           set +e
           ./tools/jenkins-runner -p 2 ${nose_args}

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -137,7 +137,7 @@
           PATH="$PWD/tools:$PATH"
 
           ./tools/vmtest-system-setup
-          ./tools/curtainer --"$TYPE" ubuntu-daily:"$RELEASE" "$LXC_NAME"
+          ./tools/curtainer --"$TYPE" ubuntu-minimal-daily:"$RELEASE" "$LXC_NAME"
           set +e
           ./tools/jenkins-runner -p 2
           RET=$?


### PR DESCRIPTION
This assumes the ubuntu-minimal-daily remote is correctly setup on the
Jenkins nodes. This is done by running:

  lxc remote add --protocol simplestreams ubuntu-minimal-daily \
      https://cloud-images.ubuntu.com/minimal/daily/

The jenkins-slave-setup Ansible playbook takes care of this, and also
sets up the ubuntu-minimal remote for released images.