### PR TITLE
Test the COPR build on CentOS 8

### DIFF
--- a/cloud-init/centos.yaml
+++ b/cloud-init/centos.yaml
@@ -23,7 +23,7 @@
     publishers:
       - email-server-crew
       - trigger:
-          project: cloud-init-copr-test-7
+          project: cloud-init-copr-test-8
           threshold: SUCCESS
     wrappers:
       - workspace-cleanup
@@ -50,7 +50,7 @@
           for i in 0 5m 30m 1h; do sleep $i; $retry_cmd && s=0 && break || s=$?; done; (exit $s)
 
 - job:
-    name: cloud-init-copr-test-7
+    name: cloud-init-copr-test-8
     node: torkoal
     wrappers:
       - workspace-cleanup
@@ -64,4 +64,4 @@
 
           git clone --depth 1 https://github.com/canonical/server-test-scripts
           cd server-test-scripts/cloud-init
-          ./copr_test -vv 7
+          ./copr_test -vv 8

--- a/cloud-init/default.yaml
+++ b/cloud-init/default.yaml
@@ -19,7 +19,7 @@
     name: cloud-init
     jobs:
       - cloud-init-copr-build
-      - cloud-init-copr-test-7
+      - cloud-init-copr-test-8
       - cloud-init-github-mirror
       - cloud-init-integration-ec2-b
       - cloud-init-integration-ec2-f


### PR DESCRIPTION
Test the copr build on centos 8 instead of centos 7. We are not even
building for centos 7 anymore due to missing Python 3 dependencies.