### PR TITLE
Add vm jobs to ubuntu-advantange-client

### DIFF
--- a/ubuntu-advantage-client/default.yaml
+++ b/ubuntu-advantage-client/default.yaml
@@ -17,7 +17,12 @@
 
 - project:
     name: ubuntu-advantage-client
+    ubunturelease:
+      - 16.04
+      - 18.04
+      - 20.04
     jobs:
+      - uaclient-vm-{ubunturelease}
       - ubuntu-advantage-client-integration-ec2-terminate
 
 - defaults:

--- a/ubuntu-advantage-client/jobs.yaml
+++ b/ubuntu-advantage-client/jobs.yaml
@@ -1,5 +1,5 @@
 # Ubuntu Server QA Jenkins Jobs
-# Copyright (C) 2016 Canonical Ltd.
+# Copyright (C) 2020 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +15,28 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 
+- job-template:
+    name: uaclient-vm-{ubunturelease}
+    parameters:
+      - uaclient
+    wrappers:
+      - workspace-cleanup
+      - timeout:
+          timeout: 50
+          fail: true
+    publishers:
+      - email-server-crew
+    triggers:
+      - timed: '@daily'
+    builders:
+      - shell: |
+          #!/bin/bash
+          set -ex
+
+          git clone --depth 1 -b "$UABRANCH" "$UAREPO" ua-client
+          cd ua-client
+          tox -e behave-vm-{ubunturelease}
+
 - job:
     name: ubuntu-advantage-client-integration-ec2-terminate
     node: torkoal
@@ -22,6 +44,8 @@
       - workspace-cleanup
     publishers:
       - email-server-crew
+    triggers:
+      - timed: '@daily'
     builders:
       - shell: |
           OLDER_THAN_DATE=`date -d yesterday +%m/%d/%y`

--- a/ubuntu-advantage-client/parameters.yaml
+++ b/ubuntu-advantage-client/parameters.yaml
@@ -1,0 +1,38 @@
+# Ubuntu Server QA Jenkins Jobs
+# Copyright (C) 2016 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version..
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+- parameter:
+    name: git-clone-params
+    parameters:
+      - string:
+            name: '{gitvarprefix}REPO'
+            default: '{giturl}'
+            description: '{gitproject} repository location'
+      - string:
+            name: '{gitvarprefix}BRANCH'
+            default: '{gitbranch|master}'
+            description: '{gitproject} branch to pull'
+
+
+# Sets the UAREPO and UABRANCH environment variables
+- parameter:
+    name: uaclient
+    parameters:
+      - git-clone-params:
+          gitproject: ubuntu-advantage-client
+          giturl: 'https://github.com/canonical/ubuntu-advantage-client.git'
+          gitvarprefix: UA


### PR DESCRIPTION
Running the full set of uaclient test in travis CI is taking a lot of time (around 2h30), we want to move some of these tests to a daily jenkins job.

We are starting by moving the vm tests, which are currently not been run on travis due to time concerns as well. We will move other test in the near future.

PS: We cannot merge this branch until this [PR](https://github.com/canonical/ubuntu-advantage-client/pull/1204) lands in uaclient, since it sets some necessary definitions for vm tests to run