### PR TITLE
deploy: allow to specify location and jobs to deploy

### DIFF
--- a/jenkins-jobs/admin/deploy.yaml
+++ b/jenkins-jobs/admin/deploy.yaml
@@ -32,6 +32,7 @@
           description: Delete jobs that were jobs once managed by JJB
             (as distinguished by a special comment that JJB appends to their
             description), but were not generated in this JJB run.
+      - git-params-server-jenkins-jobs
     wrappers:
       - credentials-binding:
           - text:
@@ -62,7 +63,7 @@
           jenkins-jobs --version
 
           rm -rf server-jenkins-jobs
-          git clone --depth 1 https://github.com/canonical/server-jenkins-jobs
+          git clone --depth 1 -b "$SJJBRANCH" "$SJJREPO" server-jenkins-jobs || exit 1
           cd server-jenkins-jobs || exit 1
 
           # Do not attempt a deploy if the jobs don't test clean

--- a/jenkins-jobs/admin/deploy.yaml
+++ b/jenkins-jobs/admin/deploy.yaml
@@ -32,6 +32,9 @@
           description: Delete jobs that were jobs once managed by JJB
             (as distinguished by a special comment that JJB appends to their
             description), but were not generated in this JJB run.
+      - string:
+          name: job_names
+          description: Space-separated list of jobs to deploy (empty = all).
       - git-params-server-jenkins-jobs
     wrappers:
       - credentials-binding:
@@ -79,4 +82,7 @@
           jjb_update_flags=(--recursive)
           [[ $delete_old == true ]] && jjb_update_flags+=(--delete-old)
 
-          jenkins-jobs "${jjb_flags[@]}" update "${jjb_update_flags[@]}" jenkins-jobs || exit 1
+          # Convert job_names to an array. Allows individual quoting of job names.
+          read -r -a job_names <<< "${job_names-}"
+
+          jenkins-jobs "${jjb_flags[@]}" update "${jjb_update_flags[@]}" jenkins-jobs "${job_names[@]}" || exit 1

--- a/jenkins-jobs/admin/parameters.yaml
+++ b/jenkins-jobs/admin/parameters.yaml
@@ -1,0 +1,24 @@
+# Ubuntu Server QA Jenkins Jobs
+# Copyright (C) 2020 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version..
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+- parameter:
+    name: git-params-server-jenkins-jobs
+    parameters:
+      - git-clone-params:
+          gitproject: server-jenkins-jobs
+          giturl: 'https://github.com/canonical/server-jenkins-jobs.git'
+          gitvarprefix: SJJ


### PR DESCRIPTION
Allows easier testing of new job definition before submitting PRs.
