### PR TITLE
Add staging token to gcpgeneric jobs

### DIFF
--- a/jenkins-jobs/ubuntu-advantage-client/jobs.yaml
+++ b/jenkins-jobs/ubuntu-advantage-client/jobs.yaml
@@ -495,6 +495,9 @@
           - text:
               credential-id: ua-contract-token
               variable: UACLIENT_BEHAVE_CONTRACT_TOKEN
+          - text:
+              credential-id: ua-contract-token-staging
+              variable: UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING
           - file:
               credential-id: ua-gce-account
               variable: UACLIENT_BEHAVE_GCP_CREDENTIALS_PATH


### PR DESCRIPTION
Xenial and Bionic GCP generic jobs require the staging token to run, but we are not binding this credential in the job definition.