### PR TITLE
oci: update namespaces and provide aws region

### DIFF
--- a/jenkins-jobs/oci/unit.yaml
+++ b/jenkins-jobs/oci/unit.yaml
@@ -133,6 +133,7 @@
             set -eufx
 
             export https_proxy=http://squid.internal:3128
+            export AWS_PROFILE=ubuntu
 
             git clone --depth 1 -b "$STSBRANCH" "$STSREPO" sts
             cd sts/oci-unit-tests

--- a/jenkins-jobs/oci/unit.yaml
+++ b/jenkins-jobs/oci/unit.yaml
@@ -17,18 +17,31 @@
 
 - project:
     name: oci-unit-tests
+    namespaces:
+      - ubuntu
+      - lts
     testcase:
       - postgres
       - redis
       - mysql
       - nginx
-      - prometheus
+      - prometheus:
+          namespaces:
+            - ubuntu
       - apache2
-      - prometheus-alertmanager
+      - prometheus-alertmanager:
+          namespaces:
+            - ubuntu
       - memcached
-      - grafana
-      - cortex
-      - telegraf
+      - grafana:
+          namespaces:
+            - ubuntu
+      - cortex:
+          namespaces:
+            - ubuntu
+      - telegraf:
+          namespaces:
+            - ubuntu
     jobs:
       - oci-unit-{testcase}
       - oci-unit-{testcase}-standalone
@@ -97,9 +110,7 @@
       - axis:
           type: user-defined
           name: DOCKER_NAMESPACE
-          values:
-            - ubuntu
-            - lts
+          values: '{namespaces}'
       - axis:
           type: user-defined
           name: DOCKER_TAG


### PR DESCRIPTION
- oci: skip the lts tests for non-lts packages
- oci unit: set AWS_PROFILE to allow logging in to public.ecr.aws
