### PR TITLE
Handle tag conflicts in git-ubuntu MPs

### DIFF
--- a/jenkins-jobs/git-ubuntu/jobs-ci.yaml
+++ b/jenkins-jobs/git-ubuntu/jobs-ci.yaml
@@ -93,7 +93,7 @@
 
             stage ('Build') {
                 steps {
-                    sh "uvt-kvm ssh --insecure $VM_NAME -- no_proxy=launchpad.net git clone -b ${params.landing_candidate_branch} ${params.landing_candidate} git-ubuntu"
+                    sh "uvt-kvm ssh --insecure $VM_NAME -- no_proxy=launchpad.net git clone --no-tags -b ${params.landing_candidate_branch} ${params.landing_candidate} git-ubuntu"
                     sh 'uvt-kvm ssh --insecure $VM_NAME -- "cd git-ubuntu && no_proxy=launchpad.net git fetch --tags https://git.launchpad.net/usd-importer"'
                     sh 'uvt-kvm ssh --insecure "$VM_NAME" -- "cd git-ubuntu; no_proxy=canonical.com,launchpad.net,launchpadlibrarian.net sh snap.sh"'
                     sh 'scp -oStrictHostKeyChecking=no ubuntu@$(uvt-kvm ip "$VM_NAME"):/home/ubuntu/git-ubuntu/git-ubuntu_*_amd64.snap .'


### PR DESCRIPTION
If an MP submitter has a tag in their repo that collides with a tag in our main repo, then `git fetch --tags` against our main repo fails. We need the main repo tags to help `git describe` generate a suitable version string for the built snap. We don't need the submitter's tags at all, so we can just avoid fetching their tags and this avoids the issue.