### PR TITLE
OCI: use ecr creds to pull images for the unit tests

### DIFF
--- a/jenkins-jobs/oci/unit.yaml
+++ b/jenkins-jobs/oci/unit.yaml
@@ -126,6 +126,13 @@
           fail: true
       - timestamps
       - workspace-cleanup
+      - credentials-binding:
+          - file:
+              credential-id: aws-ecr-ro-config
+              variable: AWS_CONFIG_FILE
+          - file:
+              credential-id: aws-ecr-ro-credentials
+              variable: AWS_SHARED_CREDENTIALS_FILE
     builders:
       - shell:
           unstable-return: 99

--- a/jenkins-jobs/oci/unit.yaml
+++ b/jenkins-jobs/oci/unit.yaml
@@ -142,7 +142,7 @@
             set -eufx
 
             export https_proxy=http://squid.internal:3128
-            export AWS_PROFILE=ubuntu
+            export AWS_PROFILE="$DOCKER_NAMESPACE"
 
             git clone --depth 1 -b "$STSBRANCH" "$STSREPO" sts
             cd sts/oci-unit-tests


### PR DESCRIPTION
- oci: use the aws ecr creds when pulling images for the unit tests
- oci unit: set AWS_PROFILE according to DOCKER_NAMESPACE
