### PR TITLE
cloud-init-style-tip: clone from GitHub and not from the LP mirror

### DIFF
--- a/jenkins-jobs/cloud-init/other.yaml
+++ b/jenkins-jobs/cloud-init/other.yaml
@@ -30,7 +30,7 @@
           export https_proxy="http://squid.internal:3128"
           export no_proxy=launchpad.net
 
-          git clone https://git.launchpad.net/cloud-init
+          git clone https://github.com/canonical/cloud-init
           cd cloud-init
           tox -e tip-flake8
           tox -e tip-pylint


### PR DESCRIPTION
True upstream for clout-init is GitHub.
